### PR TITLE
define RT_VERSION

### DIFF
--- a/coff/coff.go
+++ b/coff/coff.go
@@ -74,7 +74,8 @@ const (
 	MASK_SUBDIRECTORY = 1 << 31
 
 	RT_ICON       = 3
-	RT_GROUP_ICON = 3 + 11
+	RT_GROUP_ICON = RT_ICON + 11
+	RT_VERSION    = 16
 	RT_MANIFEST   = 24
 )
 


### PR DESCRIPTION
This constant is currently hard-coded in goversioninfo, used to add a version manifest to the syso.