### PR TITLE
Try to support 'Windows ARM/ARM64'

### DIFF
--- a/coff/coff.go
+++ b/coff/coff.go
@@ -52,10 +52,8 @@ type RelocationEntry struct {
 const (
 	_IMAGE_REL_AMD64_ADDR32NB = 0x03
 	_IMAGE_REL_I386_DIR32NB   = 0x07
-	//#define IMAGE_REL_ARM64_ADDR32NB        0x0002  // 32 bit address w/o image base (RVA: for Data/PData/XData)
 	_IMAGE_REL_ARM64_ADDR32NB = 0x02
-	//#define IMAGE_REL_ARM_ADDR32NB          0x0002  // 32 bit address w/o image base
-	_IMAGE_REL_ARM_ADDR32NB = 0x02
+	_IMAGE_REL_ARM_ADDR32NB   = 0x02
 )
 
 type Auxiliary [18]byte

--- a/coff/coff.go
+++ b/coff/coff.go
@@ -52,6 +52,10 @@ type RelocationEntry struct {
 const (
 	_IMAGE_REL_AMD64_ADDR32NB = 0x03
 	_IMAGE_REL_I386_DIR32NB   = 0x07
+	//#define IMAGE_REL_ARM64_ADDR32NB        0x0002  // 32 bit address w/o image base (RVA: for Data/PData/XData)
+	_IMAGE_REL_ARM64_ADDR32NB = 0x02
+	//#define IMAGE_REL_ARM_ADDR32NB          0x0002  // 32 bit address w/o image base
+	_IMAGE_REL_ARM_ADDR32NB = 0x02
 )
 
 type Auxiliary [18]byte
@@ -161,6 +165,10 @@ func (coff *Coff) Arch(arch string) error {
 		// https://github.com/yasm/yasm/blob/7160679eee91323db98b0974596c7221eeff772c/modules/objfmts/coff/coff-objfmt.c#L38
 		// FIXME: currently experimental -- not sure if something more doesn't need to be changed
 		coff.Machine = pe.IMAGE_FILE_MACHINE_AMD64
+	case "arm":
+		coff.Machine = pe.IMAGE_FILE_MACHINE_ARMNT
+	case "arm64":
+		coff.Machine = pe.IMAGE_FILE_MACHINE_ARM64
 	default:
 		return errors.New("coff: unknown architecture: " + arch)
 	}
@@ -253,6 +261,10 @@ func (coff *Coff) AddResource(kind uint32, id uint16, data Sizer) {
 		re.Type = _IMAGE_REL_I386_DIR32NB
 	case pe.IMAGE_FILE_MACHINE_AMD64:
 		re.Type = _IMAGE_REL_AMD64_ADDR32NB
+	case pe.IMAGE_FILE_MACHINE_ARMNT:
+		re.Type = _IMAGE_REL_ARM_ADDR32NB
+	case pe.IMAGE_FILE_MACHINE_ARM64:
+		re.Type = _IMAGE_REL_ARM64_ADDR32NB
 	}
 	coff.Relocations = append(coff.Relocations, re)
 	coff.SectionHeader32.NumberOfRelocations++

--- a/coff/coff.go
+++ b/coff/coff.go
@@ -166,8 +166,11 @@ func (coff *Coff) Arch(arch string) error {
 		// FIXME: currently experimental -- not sure if something more doesn't need to be changed
 		coff.Machine = pe.IMAGE_FILE_MACHINE_AMD64
 	case "arm":
+		// see
+		// https://github.com/golang/go/blob/f3424ceff2fa48615ed98580f337ab044925c940/src/cmd/link/internal/ld/pe.go#L736
 		coff.Machine = pe.IMAGE_FILE_MACHINE_ARMNT
 	case "arm64":
+		// Waiting https://github.com/golang/go/issues/36439
 		coff.Machine = pe.IMAGE_FILE_MACHINE_ARM64
 	default:
 		return errors.New("coff: unknown architecture: " + arch)

--- a/rsrc.go
+++ b/rsrc.go
@@ -8,8 +8,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/akavel/rsrc/coff"
 	"github.com/akavel/rsrc/binutil"
+	"github.com/akavel/rsrc/coff"
 	"github.com/akavel/rsrc/internal"
 	"github.com/akavel/rsrc/rsrc"
 )
@@ -36,7 +36,7 @@ func main() {
 	flags.StringVar(&fnameico, "ico", "", "comma-separated list of paths to .ico files to embed")
 	flags.StringVar(&fnamedata, "data", "", "path to raw data file to embed [WARNING: useless for Go 1.4+]")
 	flags.StringVar(&fnameout, "o", "rsrc.syso", "name of output COFF (.res or .syso) file")
-	flags.StringVar(&arch, "arch", "386", "architecture of output file - one of: 386, [EXPERIMENTAL: amd64]")
+	flags.StringVar(&arch, "arch", "386", "architecture of output file - one of: 386, amd64, [EXPERIMENTAL: arm, arm64]")
 	_ = flags.Parse(os.Args[1:])
 	if fnameout == "" || (fnamein == "" && fnamedata == "" && fnameico == "") {
 		fmt.Fprintf(os.Stderr, usage, os.Args[0])


### PR DESCRIPTION
What hinders this work is that Golang does not currently support Windows ARM64, and Windows ARM does not support it well.

Wating: [all: port to Windows/arm64](https://github.com/golang/go/issues/36439)