### PR TITLE
Fix for resource data alignment.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,3 +2,4 @@ Force Charlie <ipvb@qq.com>
 Mateusz Czapliński <czapkofan@gmail.com>
 Quentin Renard <contact@asticode.com>
 shnmng <shnmng@gmail.com>
+Thomas Combeléran

--- a/binutil/align.go
+++ b/binutil/align.go
@@ -1,0 +1,21 @@
+package binutil
+
+type Sizer interface {
+	Size() int64
+}
+
+type AlignedSizer interface {
+	Size() int64
+	AlignedSize() int64
+}
+
+func Align(s int64) int64 {
+	return (s-1)&^7 + 8
+}
+
+func RoomTaken(s Sizer) int64 {
+	if as, ok := s.(AlignedSizer); ok {
+		return as.AlignedSize()
+	}
+	return s.Size()
+}

--- a/binutil/align.go
+++ b/binutil/align.go
@@ -1,7 +1,17 @@
 package binutil
 
+import "io"
+
 type Sizer interface {
 	Size() int64
+}
+
+type AlignedSectionReader struct {
+	*io.SectionReader
+}
+
+func (a AlignedSectionReader) AlignedSize() int64 {
+	return Align(a.Size())
 }
 
 type AlignedSizer interface {

--- a/binutil/sizedfile.go
+++ b/binutil/sizedfile.go
@@ -17,6 +17,7 @@ type SizedFile struct {
 
 func (r *SizedFile) Read(p []byte) (n int, err error) { return r.s.Read(p) }
 func (r *SizedFile) Size() int64                      { return r.s.Size() }
+func (r *SizedFile) AlignedSize() int64               { return Align(r.s.Size()) }
 func (r *SizedFile) Close() error                     { return r.f.Close() }
 
 func SizedOpen(filename string) (*SizedFile, error) {

--- a/binutil/walk.go
+++ b/binutil/walk.go
@@ -46,6 +46,7 @@ func walk(v reflect.Value, spath string, walker Walker) error {
 		}
 		if sz, ok := v.Interface().(AlignedSizer); ok {
 			n := sz.AlignedSize() - sz.Size()
+			var pad [8]byte
 			p := pad[:n]
 			err = walk(reflect.ValueOf(p), path.Join(spath, "align"), walker)
 			if stopping(err) {

--- a/binutil/walk.go
+++ b/binutil/walk.go
@@ -44,6 +44,16 @@ func walk(v reflect.Value, spath string, walker Walker) error {
 		if stopping(err) {
 			return err
 		}
+		if sz, ok := v.Interface().(AlignedSizer); ok {
+			n := sz.AlignedSize() - sz.Size()
+			if n > 0 {
+				p := pad[:n]
+				err = walk(reflect.ValueOf(p), "", walker)
+				if stopping(err) {
+					return err
+				}
+			}
+		}
 	case reflect.Struct:
 		//t := v.Type()
 		for i := 0; i < v.NumField(); i++ {

--- a/binutil/walk.go
+++ b/binutil/walk.go
@@ -46,12 +46,10 @@ func walk(v reflect.Value, spath string, walker Walker) error {
 		}
 		if sz, ok := v.Interface().(AlignedSizer); ok {
 			n := sz.AlignedSize() - sz.Size()
-			if n > 0 {
-				p := pad[:n]
-				err = walk(reflect.ValueOf(p), "", walker)
-				if stopping(err) {
-					return err
-				}
+			p := pad[:n]
+			err = walk(reflect.ValueOf(p), path.Join(spath, "align"), walker)
+			if stopping(err) {
+				return err
 			}
 		}
 	case reflect.Struct:

--- a/binutil/writer.go
+++ b/binutil/writer.go
@@ -29,5 +29,14 @@ func (w *Writer) WriteFromSized(r SizedReader) {
 	}
 	var n int64
 	n, w.Err = io.CopyN(w.W, r, r.Size())
+	if w.Err != nil {
+		return
+	}
+	aligned := (n-1)&^7 + 8
+	if aligned > n {
+		var z [8]byte
+		w.W.Write(z[:aligned-n])
+		n = aligned
+	}
 	w.Offset += uint32(n)
 }

--- a/binutil/writer.go
+++ b/binutil/writer.go
@@ -35,9 +35,10 @@ func (w *Writer) WriteFromSized(r SizedReader) {
 		return
 	}
 	aligned := RoomTaken(r)
-	if aligned > n {
-		w.W.Write(pad[:aligned-n])
-		n = aligned
+	_, w.Err = w.W.Write(pad[:aligned-n])
+	if w.Err != nil {
+		return
 	}
+	n = aligned
 	w.Offset += uint32(n)
 }

--- a/binutil/writer.go
+++ b/binutil/writer.go
@@ -6,8 +6,6 @@ import (
 	"reflect"
 )
 
-var pad [8]byte
-
 type Writer struct {
 	W      io.Writer
 	Offset uint32 //FIXME: int64?
@@ -35,6 +33,7 @@ func (w *Writer) WriteFromSized(r SizedReader) {
 		return
 	}
 	aligned := RoomTaken(r)
+	var pad [8]byte
 	_, w.Err = w.W.Write(pad[:aligned-n])
 	if w.Err != nil {
 		return

--- a/binutil/writer.go
+++ b/binutil/writer.go
@@ -34,7 +34,7 @@ func (w *Writer) WriteFromSized(r SizedReader) {
 	if w.Err != nil {
 		return
 	}
-	aligned := Align(r.Size())
+	aligned := RoomTaken(r)
 	if aligned > n {
 		w.W.Write(pad[:aligned-n])
 		n = aligned

--- a/binutil/writer.go
+++ b/binutil/writer.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 )
 
+var pad [8]byte
+
 type Writer struct {
 	W      io.Writer
 	Offset uint32 //FIXME: int64?
@@ -32,10 +34,9 @@ func (w *Writer) WriteFromSized(r SizedReader) {
 	if w.Err != nil {
 		return
 	}
-	aligned := (n-1)&^7 + 8
+	aligned := Align(r.Size())
 	if aligned > n {
-		var z [8]byte
-		w.W.Write(z[:aligned-n])
+		w.W.Write(pad[:aligned-n])
 		n = aligned
 	}
 	w.Offset += uint32(n)

--- a/coff/coff.go
+++ b/coff/coff.go
@@ -336,7 +336,7 @@ func freezeCommon2(v reflect.Value, offset *uint32) error {
 	}
 	vv, ok := v.Interface().(Sizer)
 	if ok {
-		*offset += uint32(vv.Size())
+		*offset += uint32((vv.Size()-1)&^7 + 8)
 		return binutil.WALK_SKIP
 	}
 	return nil

--- a/rsrc/rsrc.go
+++ b/rsrc/rsrc.go
@@ -89,7 +89,7 @@ func addIcon(out *coff.Coff, fname string, newid func() uint16) (io.Closer, erro
 		}}
 		for _, icon := range icons {
 			id := newid()
-			r := io.NewSectionReader(f, int64(icon.ImageOffset), int64(icon.BytesInRes))
+			r := binutil.AlignedSectionReader{SectionReader: io.NewSectionReader(f, int64(icon.ImageOffset), int64(icon.BytesInRes))}
 			out.AddResource(coff.RT_ICON, id, r)
 			group.Entries = append(group.Entries, _GRPICONDIRENTRY{icon.IconDirEntryCommon, id})
 		}

--- a/rsrc/rsrc.go
+++ b/rsrc/rsrc.go
@@ -93,7 +93,7 @@ func addIcon(out *coff.Coff, fname string, newid func() uint16) (io.Closer, erro
 		}}
 		for _, icon := range icons {
 			id := newid()
-			r := binutil.AlignedSectionReader{SectionReader: io.NewSectionReader(f, int64(icon.ImageOffset), int64(icon.BytesInRes))}
+			r := binutil.AlignedSectionReader{io.NewSectionReader(f, int64(icon.ImageOffset), int64(icon.BytesInRes))}
 			out.AddResource(coff.RT_ICON, id, r)
 			group.Entries = append(group.Entries, _GRPICONDIRENTRY{icon.IconDirEntryCommon, id})
 		}

--- a/rsrc/rsrc.go
+++ b/rsrc/rsrc.go
@@ -23,6 +23,10 @@ func (group _GRPICONDIR) Size() int64 {
 	return int64(binary.Size(group.ICONDIR) + len(group.Entries)*binary.Size(group.Entries[0]))
 }
 
+func (group _GRPICONDIR) AlignedSize() int64 {
+	return binutil.Align(group.Size())
+}
+
 type _GRPICONDIRENTRY struct {
 	ico.IconDirEntryCommon
 	Id uint16


### PR DESCRIPTION
Probably fixes #12 and #26

Resource data has to be aligned, otherwise Windows and other tools might not read them properly.
I checked that with Resource Hacker, UPX and Windows.
windres does align resources too.

People are starting to use my fork, which is wrong because I'd never maintain it, so I'm making this pull request even though I'm not sure my fix is "right". I hope you'll find some time to review and pull it.

Thanks.