### PR TITLE
Fix data padding

### DIFF
--- a/coff/coff.go
+++ b/coff/coff.go
@@ -263,7 +263,7 @@ func (coff *Coff) AddResource(kind uint32, id uint16, data Sizer) {
 func pad(data Sizer) PaddedData {
 	return PaddedData{
 		Data:    data,
-		Padding: make([]byte, (data.Size()+7)&^7),
+		Padding: make([]byte, (data.Size()+7)&^7-data.Size()),
 	}
 }
 


### PR DESCRIPTION
Looks like you forgot to subtract actual data size.
This should explain why rsrc v0.10.0 didn't really align data, and made bigger syso files.

But, to me, this hardly explains why it was so much slower.
I suppose the magical function that explores the data directory with reflection was looping through the `Padding` slice?
