### PR TITLE
use go install instead of go get for rsrc command

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,6 +1,6 @@
 rsrc - Tool for embedding binary resources in Go programs.
 
-INSTALL: go get github.com/akavel/rsrc
+INSTALL: go install github.com/akavel/rsrc
 
 USAGE:
 


### PR DESCRIPTION
Fix for readme instruction (#43). Simple but necessary. 